### PR TITLE
BIBS-34 Add  `Session Paused` dialog on app close and phone close

### DIFF
--- a/bibs/lib/ui/session/view_models/session_viewmodel.dart
+++ b/bibs/lib/ui/session/view_models/session_viewmodel.dart
@@ -29,9 +29,9 @@ class SessionViewModel extends ChangeNotifier{
   UserProfile? _userProfile;
   UserProfile? get userProfile => _userProfile;
 
-  bool get isRunning => _stopwatch.isRunning;
+  bool get isRunning => _stopwatch.elapsedMicroseconds != 0;
 
-  bool _isPaused = false;
+  bool _isPaused = true;
   bool get isPaused => _isPaused;
 
   bool _showPausedDialogOnResume = false;
@@ -90,6 +90,7 @@ class SessionViewModel extends ChangeNotifier{
   void start() async {
     await WakelockPlus.enable();
     _stopwatch.start();
+    _isPaused = false;
     notifyListeners();
   }
   
@@ -114,10 +115,6 @@ class SessionViewModel extends ChangeNotifier{
   }
 
   Future<void> pauseOnAppInactive() async {
-    if (_isPaused) {
-      return;
-    }
-
     _stopwatch.stop();
     _isPaused = true;
     _showPausedDialogOnResume = true;
@@ -127,7 +124,6 @@ class SessionViewModel extends ChangeNotifier{
   Future<Result<void>> updateTotalTime() async {
     try {
       await WakelockPlus.disable();
-      
       _stopwatch.stop();
       int sessionDuration = _stopwatch.elapsedMilliseconds;
       _stopwatch.reset();

--- a/bibs/lib/ui/session/widgets/session_screen.dart
+++ b/bibs/lib/ui/session/widgets/session_screen.dart
@@ -43,9 +43,10 @@ class _SessionScreenState extends State<SessionScreen> with WidgetsBindingObserv
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.paused ||
+    if ((state == AppLifecycleState.paused ||
         state == AppLifecycleState.hidden ||
-        state == AppLifecycleState.inactive) {
+        state == AppLifecycleState.inactive) &&
+        (_viewModel.isRunning && !_viewModel.isPaused)) {
       _viewModel.pauseOnAppInactive();
       return;
     }
@@ -68,7 +69,7 @@ class _SessionScreenState extends State<SessionScreen> with WidgetsBindingObserv
           builder: (context) => AlertDialog(
             title: const Text('OOPS! Your session is paused.'),
             content: const Text(
-              'Looks like your session was paused because you exited the app or your phone was closed. Keep your focus, you got this!',
+              'Looks like your session was paused because you exited the app or your phone was closed.\n\nKeep your focus, you got this!',
             ),
             actions: [
               TextButton(
@@ -200,7 +201,7 @@ class _SessionScreenState extends State<SessionScreen> with WidgetsBindingObserv
           child: const Text("End session"),
         ),
       ];
-    } else if (_viewModel.isPaused) {
+    } else if (_viewModel.isRunning && _viewModel.isPaused) {
       return [
         ElevatedButton(
           onPressed: _viewModel.pauseUnpause,


### PR DESCRIPTION
Closes #34 (BIBS-34)

### Context
Currently when the timer is running, and either the app is exited or the phone is closed, the timer stops.
This PR introduces a dialog that shows up whenever the user comes back after, either the app being exited or the phone being closed, while a session was running and the timer wasn't paused.

### Implementation details
* add dialog in session screen
* add logic for showing dialog

### Screenshots
<img width="429" height="870" alt="Screenshot 2026-02-24 at 22 56 10" src="https://github.com/user-attachments/assets/2a895c61-49ba-4118-ac62-af867fa7b165" />
